### PR TITLE
FOR UPDATE OF implementation

### DIFF
--- a/include/query.hrl
+++ b/include/query.hrl
@@ -13,5 +13,6 @@
             on_conflict = #{} :: #{q:conflict_target() => q:conflict_action()},
             limit :: non_neg_integer() | undefined,
             offset :: non_neg_integer() | undefined,
-            for_update = false :: boolean()
+            for_update = false :: boolean(),
+            for_update_of = undefined :: iolist()
          }).

--- a/src/q.erl
+++ b/src/q.erl
@@ -352,7 +352,7 @@ for_update_of(V) -> fun(Q) -> for_update_of(Q, V) end.
 
 -spec for_update_of(Q, model()) -> Q when Q :: query().
 for_update_of(Q, T) ->
-    TName = equery_utils:wrap(get_table(T)),
+    TName = equery_utils:wrap(get_table_name(T)),
     Q#query{for_update_of=TName}.
 
 -spec data(fun((data()) -> data())) -> qfun().
@@ -390,8 +390,8 @@ call(Fun, Args) -> apply(equery_pt:transform_fun(Fun), Args).
 get_schema(Schema) when is_map(Schema) -> Schema;
 get_schema(Module) when is_atom(Module) -> (Module:schema())#{model => Module}.
 
-get_table(#{table := Table}) -> Table;
-get_table(Module) when is_atom(Module) -> #{table := Table} = Module:schema(), Table.
+get_table_name(#{table := Table}) -> Table;
+get_table_name(Module) when is_atom(Module) -> #{table := Table} = Module:schema(), Table.
 
 aliased_fields(TRef, Fields) ->
     maps:map(fun(F, Opts) ->

--- a/src/q.erl
+++ b/src/q.erl
@@ -352,7 +352,7 @@ for_update_of(V) -> fun(Q) -> for_update_of(Q, V) end.
 
 -spec for_update_of(Q, model()) -> Q when Q :: query().
 for_update_of(Q, T) ->
-    TName = get_table(T),
+    TName = equery_utils:wrap(get_table(T)),
     Q#query{for_update_of=TName}.
 
 -spec data(fun((data()) -> data())) -> qfun().
@@ -390,8 +390,8 @@ call(Fun, Args) -> apply(equery_pt:transform_fun(Fun), Args).
 get_schema(Schema) when is_map(Schema) -> Schema;
 get_schema(Module) when is_atom(Module) -> (Module:schema())#{model => Module}.
 
-get_table(#{table := Table}) -> equery_utils:wrap(Table);
-get_table(Module) when is_atom(Module) -> #{table := Table} = Module:schema(), equery_utils:wrap(Table).
+get_table(#{table := Table}) -> Table;
+get_table(Module) when is_atom(Module) -> #{table := Table} = Module:schema(), Table.
 
 aliased_fields(TRef, Fields) ->
     maps:map(fun(F, Opts) ->

--- a/src/q.erl
+++ b/src/q.erl
@@ -25,6 +25,7 @@
          limit/1, limit/2,
          offset/1, offset/2,
          for_update/0, for_update/1,
+         for_update_of/1, for_update_of/2,
 
          distinct/0, distinct/1,
          distinct_on/1, distinct_on/2
@@ -346,6 +347,14 @@ for_update() -> fun(Q) -> for_update(Q) end.
 for_update(Q) ->
     Q#query{for_update=true}.
 
+-spec for_update_of(model()) -> qfun().
+for_update_of(V) -> fun(Q) -> for_update_of(Q, V) end.
+
+-spec for_update_of(Q, model()) -> Q when Q :: query().
+for_update_of(Q, T) ->
+    TName = get_table(T),
+    Q#query{for_update_of=TName}.
+
 -spec data(fun((data()) -> data())) -> qfun().
 data(Fun) -> fun(Q) -> data(Fun, Q) end.
 
@@ -380,6 +389,9 @@ call(Fun, Args) -> apply(equery_pt:transform_fun(Fun), Args).
 
 get_schema(Schema) when is_map(Schema) -> Schema;
 get_schema(Module) when is_atom(Module) -> (Module:schema())#{model => Module}.
+
+get_table(#{table := Table}) -> equery_utils:wrap(Table);
+get_table(Module) when is_atom(Module) -> #{table := Table} = Module:schema(), equery_utils:wrap(Table).
 
 aliased_fields(TRef, Fields) ->
     maps:map(fun(F, Opts) ->

--- a/src/qsql.erl
+++ b/src/qsql.erl
@@ -23,7 +23,8 @@ select(#query{
             order_by=OrderBy,
             limit=Limit,
             offset=Offset,
-            for_update=ForUpdate
+            for_update=ForUpdate,
+            for_update_of=ForUpdateOf
          }) ->
     {Fields, Opts} = fields_and_opts(Schema, RFields),
     qast:exp([
@@ -38,7 +39,8 @@ select(#query{
         order_by_exp(OrderBy),
         limit_exp(Limit),
         offset_exp(Offset),
-        for_update(ForUpdate)
+        for_update(ForUpdate),
+        for_update_of(ForUpdateOf, Tables)
     ], Opts).
 
 -spec insert(q:query()) -> qast:ast_node().
@@ -290,3 +292,12 @@ for_update(true) ->
     qast:raw(" for update");
 for_update(false) ->
     qast:raw("").
+
+for_update_of(undefined, _Tables) ->
+    qast:raw("");
+for_update_of(Table, Tables) ->
+    [TRef] = [Ref || {real, T, Ref} <- Tables, T =:= Table],
+    qast:exp([
+        qast:raw(" for update of "),
+        qast:alias(TRef)
+    ]).


### PR DESCRIPTION
The `FOR UPDATE` statement is not working with join queries. 
`FOR UPDATE cannot be applied to the nullable side of an outer join`
A lock on a select result means that you've guaranteed that no one else can change the rows you selected. In an outer join it's impossible to guarantee that. But in some cases we can use `FOR UPDATE OF from_reference` instead.